### PR TITLE
Allow plotting functions to take in function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ gitbook: ## Runs gitbook locally
 	gitbook install
 	gitbook serve
 
+test: ## Run tests
+	python setup.py test
+
 
 
 start_notebook:

--- a/docs/textbook/basics_graphing.ipynb
+++ b/docs/textbook/basics_graphing.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "# Interactive Visualizations\n",
     "\n",
-    "`ipywidgets` and `nbinteract` allow you to quickly create and publish interactive visualizations. We'll start with an easier ways to create interactive graphs using `matplotlib` and then introduce some of the built-in plotting tools in `nbinteract`."
+    "`ipywidgets` and `nbinteract` allow you to quickly create and publish interactive visualizations. We'll start with the simplest way to create interactive graphs using `matplotlib` and then introduce some of the built-in plotting tools in `nbinteract`."
    ]
   },
   {
@@ -44,7 +44,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dd48d930c73d4599aa6a749942142edb",
+       "model_id": "1bc26fe6b9ec4617bbfc8ae97d0941d4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -75,7 +75,7 @@
    "source": [
     "As you might notice, the example above lags and stutters when the slider is dragged around too quickly. This is a limitation of using `matplotlib` and `matplotlib`-based plotting libraries that produce images. The lag occurs because the images are too large to generate and send over the network to match the speed of interaction.\n",
     "\n",
-    "`nbinteract` comes with a set of functions that produce Javascript-based plots designed for interaction described in the following section. Notice that in the example above the function passed into `interact` creates the plot directly. The plotting functions that come with `nbinteract`, however, require response functions to return the **data** to be plotted instead of creating the plot themselves.\n",
+    "`nbinteract` comes with a set of functions that produce Javascript-based plots designed for interaction. Notice that in the example above the function passed into `interact` creates the plot directly. Most plotting functions that come with `nbinteract`, however, require response functions to return the **data** to be plotted instead of creating the plot themselves.\n",
     "\n",
     "For brevity, we describe two examples here. For a complete list of `nbinteract` plotting functions, see the API reference."
    ]
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "metadata": {
     "scrolled": false
    },
@@ -122,7 +122,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bc91b27b285d450a9789641290ee4d4d",
+       "model_id": "a427bc4117334bd0b6cf74d149901946",
        "version_major": 2,
        "version_minor": 0
       },
@@ -136,7 +136,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "93cf9aa6535f44adbf968e7291c95097",
+       "model_id": "2866ea79a1b441bebf34ac23123d779a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -161,13 +161,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7a47e606d58e4d7d9d8ee855c1bad774",
+       "model_id": "d88e395343394f7da00ab2eb7532a926",
        "version_major": 2,
        "version_minor": 0
       },
@@ -181,7 +181,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fd4a0d0c432848189e94fb94215d0aa8",
+       "model_id": "4b7cfbbb2224457e8ab3c013debb3f79",
        "version_major": 2,
        "version_minor": 0
       },
@@ -211,13 +211,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "aadd4e80d15d4304a1e3301659269ec3",
+       "model_id": "29efac1d075f417b9f7facaae0e76881",
        "version_major": 2,
        "version_minor": 0
       },
@@ -231,7 +231,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c77a1c95be404dc59bd6b75304455410",
+       "model_id": "b23d772b0c904e5bb80a91070e885231",
        "version_major": 2,
        "version_minor": 0
       },
@@ -251,25 +251,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### nbinteract.scatter"
+    "### nbinteract.scatter_drag"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`nbinteract.scatter` takes in two lists/arrays consisting of the x-coordinates and y-coordinates of the points to plot. It generates an interactive scatter plot where the points can be dragged by the user and a best fit line is updated automatically according to the placement of the points."
+    "`nbinteract.scatter_drag` takes in two lists/arrays consisting of the x-coordinates and y-coordinates of the points to plot. It generates an interactive scatter plot where the points can be dragged by the user and a best fit line is updated automatically according to the placement of the points."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bac99b33a57e428c978656b22b153f2d",
+       "model_id": "2e1b1cc09cb3489b98d3d287645f341b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -285,8 +285,15 @@
     "x_coords = np.arange(10)\n",
     "y_coords = np.arange(10) + np.random.rand(10)\n",
     "\n",
-    "nbinteract.scatter(x_coords, y_coords, fit_reg=True)"
+    "nbinteract.scatter_drag(x_coords, y_coords, options={'xlim': (0, 9), 'ylim': (0, 11)})"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/textbook/basics_graphing.ipynb
+++ b/docs/textbook/basics_graphing.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,7 +15,9 @@
     "from ipywidgets import interact, interactive\n",
     "\n",
     "plt.style.use('fivethirtyeight')\n",
-    "%matplotlib inline"
+    "%matplotlib inline\n",
+    "import warnings\n",
+    "warnings.simplefilter(action=\"ignore\", category=FutureWarning)"
    ]
   },
   {
@@ -36,13 +38,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7a3d8d192e6f42f28a2a9dc533da8e4a",
+       "model_id": "dd48d930c73d4599aa6a749942142edb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -55,9 +57,9 @@
     }
    ],
    "source": [
-    "def response_function(y):\n",
-    "    plt.bar(np.arange(10),np.arange(10)+y)\n",
-    "interact(response_function, y=5);"
+    "def plot_plt_bar(y):\n",
+    "    plt.bar(np.arange(10), np.arange(10)+y)\n",
+    "interact(plot_plt_bar, y=5);"
    ]
   },
   {
@@ -71,73 +73,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you might notice, the example above lags and stutters when the slider is dragged around too quickly. Each time the slider value changes, a brand-new image needs to be generated and sent to the web browser which takes too long to feel interactive.\n",
+    "As you might notice, the example above lags and stutters when the slider is dragged around too quickly. This is a limitation of using `matplotlib` and `matplotlib`-based plotting libraries that produce images. The lag occurs because the images are too large to generate and send over the network to match the speed of interaction.\n",
     "\n",
-    "`nbinteract` comes with a set of functions that  \n",
+    "`nbinteract` comes with a set of functions that produce Javascript-based plots designed for interaction described in the following section. Notice that in the example above the function passed into `interact` creates the plot directly. The plotting functions that come with `nbinteract`, however, require response functions to return the **data** to be plotted instead of creating the plot themselves.\n",
     "\n",
-    "In place of `matplotlib`, nbinteract has built-in functions using a graphing library called `bqplot`. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### nbinteract.bar"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`nbinteract.bar` takes in a list, a function to apply to that list and any parameters needed for that function. In this case the function is taking in a list from 0..9 and passing in the `new_response_function` with `y=5` as input to that function. More extensive examples can be found in the \"Probability Distribution Plots\" section. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def bar_response_function(x_data, y):\n",
-    "    return x_data+y"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "36a1ae72d0e54350b24c0fa93cd4ae74",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "24a9e3573a784275947c05b591653461",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "nbinteract.bar(np.arange(10), bar_response_function, y=5)"
+    "For brevity, we describe two examples here. For a complete list of `nbinteract` plotting functions, see the API reference."
    ]
   },
   {
@@ -151,35 +91,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`nbinteract.hist` takes in a function that returns an array of values and any parameters needed for that function. It outputs a histogram representative of the output array and widgets to control the parameters passed in. A more complicated example can be found in the \"Central Limit Theorem\" example. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In this case the function returns a random int array of length 100. The user can control the range from [0, num]."
+    "`nbinteract.hist` takes in a single response function.\n",
+    "\n",
+    "The response function can take in any number of parameters and returns the array of numerical values that will be shown in the histogram.\n",
+    "\n",
+    "The `nbinteract.hist` function allows interaction with the response function's parameters by specifying them as keyword arguments. Any argument that can be used for `ipywidgets.interact` can be used for `nbinteract.hist`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def hist_response_function(num):\n",
-    "    return np.random.randint(num, size=100)"
+    "def hist_response_function(mean, sd, size=1000):\n",
+    "    '''\n",
+    "    Returns 1000 values picked at random from the normal\n",
+    "    distribution with the mean and SD given.\n",
+    "    '''\n",
+    "    return np.random.normal(loc=mean, scale=sd, size=1000)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "execution_count": 12,
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "20b5c564b7b64cafb998f1c18bd6aecc",
+       "model_id": "bc91b27b285d450a9789641290ee4d4d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -193,7 +136,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0bfcb6d784a74268b7818251a10b2460",
+       "model_id": "93cf9aa6535f44adbf968e7291c95097",
        "version_major": 2,
        "version_minor": 0
       },
@@ -206,7 +149,102 @@
     }
    ],
    "source": [
-    "nbinteract.hist(hist_response_function, num=(1,100))"
+    "nbinteract.hist(hist_response_function, mean=(0, 10), sd=(0, 2.0, 0.2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you interact with the above plot, you may notice that the plot's x and y-axes will automatically scale to match the input data. You can change plot parameters like the axes limits through the `options` parameter of the plotting functions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a47e606d58e4d7d9d8ee855c1bad774",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fd4a0d0c432848189e94fb94215d0aa8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "options = {\n",
+    "    'title': '1000 random points from normal distribution',\n",
+    "    'xlim': (0, 15),\n",
+    "    'ylim': (0, 800)\n",
+    "}\n",
+    "nbinteract.hist(hist_response_function, options=options, mean=(0, 10), sd=(0, 2.0, 0.2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may call `nbinteract` plotting functions with plain data as the input as well:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aadd4e80d15d4304a1e3301659269ec3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c77a1c95be404dc59bd6b75304455410",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "nbinteract.hist(np.random.normal(size=1000))"
    ]
   },
   {
@@ -220,28 +258,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`nbinteract.scatter` takes in two lists consisting of the x-coordinates and y-coordinates. Itgenerates an interactive scatter plot where the points can be dragged by the user and a best fit line is updated automatically according to the placement of the points"
+    "`nbinteract.scatter` takes in two lists/arrays consisting of the x-coordinates and y-coordinates of the points to plot. It generates an interactive scatter plot where the points can be dragged by the user and a best fit line is updated automatically according to the placement of the points."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x_coords = np.arange(10)\n",
-    "y_coords = np.arange(10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c9185722a1b74c83b8b48edfa8abb368",
+       "model_id": "bac99b33a57e428c978656b22b153f2d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -254,7 +282,10 @@
     }
    ],
    "source": [
-    "nbinteract.scatter(x_coords, y_coords)"
+    "x_coords = np.arange(10)\n",
+    "y_coords = np.arange(10) + np.random.rand(10)\n",
+    "\n",
+    "nbinteract.scatter(x_coords, y_coords, fit_reg=True)"
    ]
   }
  ],

--- a/docs/textbook/bqplot_scatter.ipynb
+++ b/docs/textbook/bqplot_scatter.ipynb
@@ -39,7 +39,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c91fc7a8f36c458a96529ea279b66fa0",
+       "model_id": "d7714f5f044c4a32b89868b6a4d0b697",
        "version_major": 2,
        "version_minor": 0
       },

--- a/docs/textbook/bqplot_scatter.ipynb
+++ b/docs/textbook/bqplot_scatter.ipynb
@@ -17,24 +17,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
-    "import warnings\n",
-    "warnings.simplefilter(action=\"ignore\", category=FutureWarning)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from nbinteract import scatter\n",
+    "from nbinteract import scatter_drag\n",
     "import numpy as np"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,13 +33,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "60e5ea82708348f29f7f4aec3a081cb1",
+       "model_id": "c91fc7a8f36c458a96529ea279b66fa0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -63,13 +52,13 @@
     }
    ],
    "source": [
-    "scatter(x, y, fit_reg=True)"
+    "scatter_drag(x, y, options={'xlim': (0, 6), 'ylim': (1, 11)})"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -83,7 +72,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/nbinteract/__init__.py
+++ b/nbinteract/__init__.py
@@ -1,3 +1,8 @@
+# Ignore warnings from bqplot. We won't use FutureWarnings ourselves so this
+# should be okay.
+import warnings
+warnings.simplefilter(action="ignore", category=FutureWarning)
+
 from .exporter import *
 from .plotting import *
 from .questions import *

--- a/nbinteract/__init__.py
+++ b/nbinteract/__init__.py
@@ -1,3 +1,4 @@
 from .exporter import *
 from .plotting import *
 from .questions import *
+from . import util

--- a/nbinteract/plotting.py
+++ b/nbinteract/plotting.py
@@ -217,7 +217,8 @@ def scatter_drag(x_points: 'Array', y_points: 'Array', show_eqn=True,
 
     # create line fit to data and display equation
     def update_line(change=None):
-        lin.x = [x_sc.min, x_sc.max]
+        lin.x = [x_sc.min if x_sc.min is not None else np.min(scat.x),
+                 x_sc.max if x_sc.max is not None else np.max(scat.x)]
         poly = np.polyfit(scat.x, scat.y, deg=1)
         lin.y = np.polyval(poly, lin.x)
         if show_eqn:

--- a/nbinteract/plotting.py
+++ b/nbinteract/plotting.py
@@ -187,7 +187,7 @@ def scatter_drag(x_points: 'Array', y_points: 'Array', show_eqn=True,
     >>> xs = np.arange(10)
     >>> ys = np.arange(10) + np.random.rand(10)
     >>> scatter_drag(xs, ys)
-    interactive(...)
+    VBox(...)
     """
     options = {**_default_options, **options}
 

--- a/nbinteract/plotting.py
+++ b/nbinteract/plotting.py
@@ -1,66 +1,159 @@
 import numpy as np
 import bqplot as bq
+import collections
 import ipywidgets as widgets
 from IPython.display import display
+
+from . import util
 
 __all__ = ['hist', 'bar', 'scatter']
 
 
-def hist(hist_function, title=None, **kwargs):
+DARK_BLUE = '#475A77'
+GOLDENROD = '#FEC62C'
+
+# Default plot options
+_default_options = {
+    'title': '',
+    'xlabel': '',
+    'ylabel': '',
+    'xlim': (None, None),
+    'ylim': (None, None),
+}
+
+PLACEHOLDER_ZEROS = np.zeros(10)
+PLACEHOLDER_RANGE = np.arange(10)
+
+
+def hist(hist_function, options={}, **interact_params):
     """
-    Generates an interactive histogram that allows users to
-    interact with parameters of hist_function and visualize changes in the
-    histogram.
+    Generates an interactive histogram that allows users to change the
+    parameters of the input hist_function.
 
     Args:
-        ''hist_function'' -- (function)
-        Function takes in parameters that should be interactive and returns
-        an array of value that reflects the modified histogram data.
+        hist_function (Array | (*args -> Array int | Array float)):
+            Function that takes in parameters to interact with and returns an
+            array of numbers. These numbers will be plotted in the resulting
+            histogram.
 
-        ''kwargs'' --
-        Parameters to pass into hist_function.
+        options (dict): Options for the plot. Available options:
+
+            title: Title of the plot
+            xlabel: Label of the x-axis
+            ylabel: Label of the y-axis
+            xlim: Tuple containing (lower, upper) for x-axis
+            ylim: Tuple containing (lower, upper) for y-axis
+
+        interact_params (dict): Keyword arguments in the same format as
+            `ipywidgets.interact`. One argument is required for each argument
+            of `hist_function`.
 
     Returns:
         None
+
+    >>> def gen_random(n_points):
+    ...     return np.random.normal(size=n_points)
+    >>> hist(gen_random, n_points=(0, 1000, 10))
+    interactive(...)
     """
-    x_sc = bq.LinearScale()
-    y_sc = bq.LinearScale()
-    ax_x = bq.Axis(label='X', scale=x_sc, grid_lines='solid')
-    ax_y = bq.Axis(label='Y', scale=y_sc, orientation='vertical',
+    options = {**_default_options, **options}
+
+    x_sc = bq.LinearScale(min=options['xlim'][0], max=options['xlim'][1])
+    y_sc = bq.LinearScale(min=options['ylim'][0], max=options['ylim'][1])
+
+    ax_x = bq.Axis(label=options['xlabel'], scale=x_sc, grid_lines='solid')
+    ax_y = bq.Axis(label=options['ylabel'], scale=y_sc, orientation='vertical',
                    grid_lines='solid')
-    hist = bq.Hist(sample=np.array(np.arange(0, 1, 0.1)),
+
+    hist = bq.Hist(sample=_array_or_placeholder(hist_function),
                    scales={'sample': x_sc, 'count': y_sc},
-                   colors=['#475A77'],
-                  stroke='#475A77')
-    fig = bq.Figure(axes=[ax_x, ax_y], marks=[hist], title=title or '')
+                   colors=[DARK_BLUE],
+                   stroke=DARK_BLUE)
+    fig = bq.Figure(axes=[ax_x, ax_y], marks=[hist], title=options['title'])
 
-    def wrapped(**kwargs):
-        hist.sample = hist_function(**kwargs)
+    def wrapped(**interact_params):
+        hist.sample = util.call_if_needed(hist_function, interact_params)
 
-    display_widgets = widgets.interactive(wrapped, **kwargs)
+    display_widgets = widgets.interactive(wrapped, **interact_params)
     display(display_widgets)
     display(fig)
 
 
-def bar(x_data, function, title=None, **kwargs):
+def bar(x_fn, y_fn, options={}, **interact_params):
+    """
+    Generates an interactive bar chart that allows users to change the
+    parameters of the inputs x_fn and y_fn.
+
+    Args:
+        x_fn (Array | (*args -> Array str | Array int | Array float)):
+            If array, uses array values for categories of bar chart.
+
+            If function, must take parameters to interact with and return an
+            array of strings or numbers. These will become the categories on
+            the x-axis of the bar chart.
+
+        y_fn (Array | (Array, *args -> Array int | Array float)):
+            If array, uses array values for heights of bars.
+
+            If function, must take in the output of x_fn as its first parameter
+            and optionally other parameters to interact with. Must return an
+            array of numbers. These will become the heights of the bars on the
+            y-axis.
+
+        options (dict): Options for the plot. Available options:
+
+            title: Title of the plot
+            xlabel: Label of the x-axis
+            ylabel: Label of the y-axis
+            ylim: Tuple containing (lower, upper) for y-axis
+
+        interact_params (dict): Keyword arguments in the same format as
+            `ipywidgets.interact`. One argument is required for each argument
+            of both `x_fn` and `y_fn`. If `x_fn` and `y_fn` have conflicting
+            parameter names, prefix the corresponding kwargs with `x__` and
+            `y__`.
+
+    Returns:
+        None
+
+    >>> bar(['a', 'b', 'c'], [4, 7, 10])
+    interactive(...)
+
+    >>> def categories(n): return np.arange(n)
+    >>> def heights(xs, offset):
+    ...     return xs + offset
+    >>> bar(categories, heights, n=(0, 10), offset=(1, 10))
+    interactive(...)
+
+    >>> def multiply(xs, n):
+    ...     return xs * n
+    >>> bar(categories, multiply, x__n=(0, 10), y__n=(1, 10))
+    interactive(...)
+    """
+    options = {**_default_options, **options}
+
     x_sc = bq.OrdinalScale()
-    y_sc = bq.LinearScale()
+    y_sc = bq.LinearScale(min=options['ylim'][0], max=options['ylim'][1])
 
-    ax_x = bq.Axis(label='X', scale=x_sc, grid_lines='solid')
-    ax_y = bq.Axis(label='Y', scale=y_sc, orientation='vertical', grid_lines='solid')
+    ax_x = bq.Axis(label=options['xlabel'], scale=x_sc, grid_lines='solid')
+    ax_y = bq.Axis(label=options['ylabel'], scale=y_sc, orientation='vertical',
+                   grid_lines='solid')
 
-    # set chart to blue
-    bar = bq.Bars(x=x_data,
-                  y=np.array(np.arange(len(x_data))),
+    bar = bq.Bars(x=_array_or_placeholder(x_fn, PLACEHOLDER_RANGE),
+                  y=_array_or_placeholder(y_fn),
                   scales={'x': x_sc, 'y': y_sc},
-                  colors=['#475A77'],
-                  stroke='#475A77')
-    fig = bq.Figure(axes=[ax_x, ax_y], marks=[bar], title=title or '')
+                  colors=[DARK_BLUE],
+                  stroke=DARK_BLUE)
+    fig = bq.Figure(axes=[ax_x, ax_y], marks=[bar], title=options['title'])
 
-    def wrapped(**kwargs):
-        bar.y = function(x_data, **kwargs)
+    def wrapped(**interact_params):
+        x_data = util.call_if_needed(x_fn, interact_params, prefix='x')
+        bar.x = x_data
 
-    display_widgets = widgets.interactive(wrapped, **kwargs)
+        y_bound = util.maybe_curry(y_fn, x_data)
+        bar.y = util.call_if_needed(y_bound, interact_params, prefix='y')
+
+    display_widgets = widgets.interactive(wrapped, **interact_params)
     display(display_widgets)
     display(fig)
 
@@ -96,8 +189,8 @@ def scatter(x_points, y_points, title=None, fit_reg=True):
     scat = bq.Scatter(x=x_points,
                       y=y_points,
                       scales={'x': sc_x, 'y': sc_y},
-                      colors=['#475A77'],
-                      stroke='#475A77',
+                      colors=[DARK_BLUE],
+                      stroke=DARK_BLUE,
                       enable_move=True)
     # equation label
     label = widgets.Label()
@@ -106,7 +199,7 @@ def scatter(x_points, y_points, title=None, fit_reg=True):
         scat.observe(update_line, names=['x', 'y'])
         lin = bq.Lines(scales={'x': sc_x, 'y': sc_y},
                        animation_duration=5000,
-                       colors=['#FEC62C'])
+                       colors=[GOLDENROD])
         fig = bq.Figure(marks=[scat, lin], axes=[ax_x, ax_y], title=title or '')
         update_line(None)
     else:
@@ -115,3 +208,46 @@ def scatter(x_points, y_points, title=None, fit_reg=True):
     box = widgets.VBox([label, fig])
     # initialize plot and equation and display
     display(box)
+
+
+def _generate_scales(x_sc_cls, y_sc_cls, options):
+    """
+    Returns (x_scale, y_scale) for a bqplot plot. Uses options to set traits
+    of the scales properly.
+
+    Args:
+        x_sc_cls (bq.Scale): Scale class for the x-axis
+
+        y_sc_cls (bq.Scale): Scale class for the y-axis
+
+        options (dict): Options are used to set traits of scales. Available
+            options:
+
+            xlim: Tuple containing (lower, upper) for x-axis
+            ylim: Tuple containing (lower, upper) for y-axis
+    """
+    x_sc = x_sc_cls()
+    y_sc = y_sc_cls()
+
+    xlim = options.get('xlim', False)
+    ylim = options.get('ylim', False)
+
+    if xlim:
+        x_sc.min, x_sc.max = xlim
+    if ylim:
+        y_sc.min, y_sc.max = ylim
+
+    return x_sc, y_sc
+
+
+def _array_or_placeholder(maybe_iterable,
+                          placeholder=PLACEHOLDER_ZEROS) -> np.array:
+    """
+    Return maybe_iterable's contents or a placeholder array.
+
+    Used to give bqplot its required initial points to plot even if we're using
+    a function to generate points.
+    """
+    if isinstance(maybe_iterable, collections.Iterable):
+        return np.array([i for i in maybe_iterable])
+    return placeholder

--- a/nbinteract/util.py
+++ b/nbinteract/util.py
@@ -1,0 +1,65 @@
+"""
+Utility functions that aren't publicly exposed.
+"""
+
+import inspect
+
+
+def get_required_args(fn) -> list:
+    """
+    Returns a list of required arguments for the function fn.
+
+    >>> def foo(x, y, z=100): return x + y + z
+    >>> get_required_args(foo)
+    ['x', 'y']
+    """
+    sig = inspect.signature(fn)
+    return [name for name, param in sig.parameters.items()
+            if param.default == inspect._empty]
+
+
+def pick_kwargs(kwargs: dict, required_args: list, prefix: str=None):
+    """
+    Given a dict of kwargs and a list of required_args, return a dict
+    containing only the args in required_args.
+
+    If prefix is specified, also search for args that begin with '{prefix}__'.
+    Removes prefix in returned dict.
+
+    Raises ValueError if both prefixed and unprefixed arg are given in kwargs.
+
+    >>> from pprint import pprint as p # Use pprint to sort dict keys
+    >>> kwargs = {'a': 1, 'b': 2, 'c': 3, 'x__d': 4}
+    >>> p(pick_kwargs(kwargs, ['a', 'd']))
+    {'a': 1}
+    >>> p(pick_kwargs(kwargs, ['a', 'd'], prefix='x'))
+    {'a': 1, 'd': 4}
+
+    >>> pick_kwargs({'a': 1, 'x__a': 2}, ['a'], prefix='x')
+    Traceback (most recent call last):
+    ValueError: Both prefixed and unprefixed args were specified for the
+    following parameters: ['a']
+    """
+    picked = {k: v for k, v in kwargs.items() if k in required_args}
+
+    prefixed = {}
+    if prefix:
+        prefix = prefix + '__'
+        prefixed = {
+            _remove_prefix(k, prefix): v
+            for k, v in kwargs.items()
+            if k.startswith(prefix)
+            and _remove_prefix(k, prefix) in required_args
+        }
+
+    conflicting_args = [k for k in picked if k in prefixed]
+    if conflicting_args:
+        raise ValueError('Both prefixed and unprefixed args were specified '
+                         'for the following parameters: {}'
+                         .format(conflicting_args))
+
+    return {**picked, **prefixed}
+
+
+def _remove_prefix(string: str, prefix: str) -> str:
+    return string.split(prefix, 1)[1]

--- a/nbinteract/util.py
+++ b/nbinteract/util.py
@@ -20,14 +20,14 @@ def get_fn_args(fn, kwargs: dict, prefix: str=None):
     >>> from pprint import pprint as p # Use pprint to sort dict keys
     >>> kwargs = {'a': 1, 'b': 2, 'c': 3, 'x__d': 4}
     >>> def foo(a, b=10): return a + b
-    >>> p(get_fn_args(foo, kwargs)
+    >>> p(get_fn_args(foo, kwargs))
     {'a': 1, 'b': 2}
 
     >>> def bar(a, b, d): return a + b + d
     >>> p(get_fn_args(bar, kwargs, prefix='x'))
-    {'a': 1, 'b': 2', 'd': 4}
+    {'a': 1, 'b': 2, 'd': 4}
 
-    >>> >>> p(get_fn_args(bar, kwargs))
+    >>> p(get_fn_args(bar, kwargs))
     Traceback (most recent call last):
     ValueError: The following args are missing for the function bar: ['d']
     """

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,36 @@ runnable HTML files.
 
 # Always prefer setuptools over distutils
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
+
 # To use a consistent encoding
 from codecs import open
 from os import path
+import sys
 
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
+
+
+class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = ['tests']
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
+
 
 setup(
     name='nbinteract',
@@ -60,8 +81,9 @@ setup(
 
     extras_require={
         'dev': ['check-manifest'],
-        'test': ['coverage'],
+        'test': ['pytest', 'coverage', 'coveralls'],
     },
+    cmdclass = {'test': PyTest},
 
     # Add exporter to nbconvert CLI:
     # https://nbconvert.readthedocs.io/en/latest/external_exporters.html

--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,8 @@ setup(
         'numpy',
         'bqplot',
         'ipywidgets',
-        'IPython'
-
+        'IPython',
+        'toolz'
     ],
 
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ class PyTest(TestCommand):
 
 setup(
     name='nbinteract',
-    version='0.0.13',
+    version='0.0.14',
     description='Export interactive HTML pages from Jupyter Notebooks',
     long_description=long_description,
     url='https://github.com/SamLau95/nbinteract',

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,10 +1,8 @@
-import doctest
-
 import nbinteract as nbi
 
-FLAGS = doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL
+from .util import run_doctests
 
 
 def test_doctests():
-    results = doctest.testmod(nbi.plotting, optionflags=FLAGS)
+    results = run_doctests(nbi.plotting)
     assert results.failed == 0

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,10 @@
+import doctest
+
+import nbinteract as nbi
+
+FLAGS = doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL
+
+
+def test_doctests():
+    results = doctest.testmod(nbi.plotting, optionflags=FLAGS)
+    assert results.failed == 0

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,10 +1,8 @@
-import doctest
-
 import nbinteract as nbi
 
-FLAGS = doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL
+from .util import run_doctests
 
 
 def test_doctests():
-    results = doctest.testmod(nbi.util, optionflags=FLAGS)
+    results = run_doctests(nbi.util)
     assert results.failed == 0

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,10 @@
+import doctest
+
+import nbinteract as nbi
+
+FLAGS = doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL
+
+
+def test_doctests():
+    results = doctest.testmod(nbi.util, optionflags=FLAGS)
+    assert results.failed == 0

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,17 @@
+"""
+Utilities for test cases. This file doesn't actually contain any test cases.
+"""
+import doctest
+
+FLAGS = (
+    doctest.NORMALIZE_WHITESPACE
+    | doctest.IGNORE_EXCEPTION_DETAIL
+    | doctest.ELLIPSIS
+)
+
+
+def run_doctests(module, flags=FLAGS):
+    """
+    Runs doctests with our default flags
+    """
+    return doctest.testmod(module, optionflags=flags)

--- a/tests/util.py
+++ b/tests/util.py
@@ -9,6 +9,22 @@ FLAGS = (
     | doctest.ELLIPSIS
 )
 
+OC = doctest.OutputChecker
+
+
+class AEOutputChecker(OC):
+    """
+    Hack to allow [...] as ellipsis in doctests in addition to the default ...
+    """
+    def check_output(self, want, got, optionflags):
+        from re import sub
+        if optionflags & doctest.ELLIPSIS:
+            want = sub(r'\[\.\.\.\]', '...', want)
+        return OC.check_output(self, want, got, optionflags)
+
+
+doctest.OutputChecker = AEOutputChecker
+
 
 def run_doctests(module, flags=FLAGS):
     """


### PR DESCRIPTION
@Calebs97 

This PR adds the ability to call plotting functions with either data or a
function for each data argument.

For example:

```
>>> bar(['a', 'b', 'c'], [4, 7, 10])
interactive(...)

>>> def categories(n): return np.arange(n)
>>> def heights(xs, offset):
...     return xs + offset
>>> bar(categories, heights, n=(0, 10), offset=(1, 10))
interactive(...)

>>> def multiply(xs, n):
...     return xs * n
>>> bar(categories, multiply, x__n=(0, 10), y__n=(1, 10))
interactive(...)
```

I also set up doctests since we actually have test cases now. Whoohoo!
  