### PR TITLE
Allow gitbook plugin to be manually run

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,7 +1,9 @@
 {
   "root": "docs",
   "plugins": ["nbinteract", "katex-plus"],
-  "links": {
-    "sidebar": false
+  "pluginsConfig": {
+    "nbinteract": {
+      "auto_run": true
+    }
   }
 }

--- a/docs/notebooks-html/recipes_nbinteract_graphing.html
+++ b/docs/notebooks-html/recipes_nbinteract_graphing.html
@@ -1,4 +1,7 @@
 <div id="ipython-notebook">
+    <div id="nbinteract" class="interact-button">
+        Interact
+    </div>
             <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
@@ -68,8 +71,8 @@
 
 
 
- 
- 
+
+
 <div id="c737efc9-1786-49ed-aa8c-a681cdca7aa3"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -87,8 +90,8 @@ var element = $('#c737efc9-1786-49ed-aa8c-a681cdca7aa3');
 
 
 
- 
- 
+
+
 <div id="4c2f368b-37fd-4eef-b85a-4562cfd7b20a"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -126,8 +129,8 @@ var element = $('#4c2f368b-37fd-4eef-b85a-4562cfd7b20a');
 
 
 
- 
- 
+
+
 <div id="5484ae8e-0077-4081-bb3e-bab912121669"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -145,8 +148,8 @@ var element = $('#5484ae8e-0077-4081-bb3e-bab912121669');
 
 
 
- 
- 
+
+
 <div id="845bc81d-899e-4783-9f38-c1644c1fbbf0"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -179,8 +182,8 @@ var element = $('#845bc81d-899e-4783-9f38-c1644c1fbbf0');
 
 
 
- 
- 
+
+
 <div id="ea925593-31e8-4bf1-9b96-7d5bd164b76a"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -198,8 +201,8 @@ var element = $('#ea925593-31e8-4bf1-9b96-7d5bd164b76a');
 
 
 
- 
- 
+
+
 <div id="5d2f9879-67cb-4fcf-b895-28532d73d3ea"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -223,7 +226,7 @@ var element = $('#5d2f9879-67cb-4fcf-b895-28532d73d3ea');
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">categories</span><span class="p">(</span><span class="n">n</span><span class="p">):</span> 
+<div class=" highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">categories</span><span class="p">(</span><span class="n">n</span><span class="p">):</span>
     <span class="k">return</span> <span class="n">np</span><span class="o">.</span><span class="n">arange</span><span class="p">(</span><span class="n">n</span><span class="p">)</span>
 
 <span class="k">def</span> <span class="nf">heights</span><span class="p">(</span><span class="n">xs</span><span class="p">,</span> <span class="n">offset</span><span class="p">):</span>
@@ -244,8 +247,8 @@ var element = $('#5d2f9879-67cb-4fcf-b895-28532d73d3ea');
 
 
 
- 
- 
+
+
 <div id="2c053358-40d0-471d-b373-ee9c1af14eb5"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -263,8 +266,8 @@ var element = $('#2c053358-40d0-471d-b373-ee9c1af14eb5');
 
 
 
- 
- 
+
+
 <div id="ec2eef7e-de90-4106-9677-5cc03f55f9a9"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -306,8 +309,8 @@ var element = $('#ec2eef7e-de90-4106-9677-5cc03f55f9a9');
 
 
 
- 
- 
+
+
 <div id="221bfcfa-4c16-4445-9eac-27d04f8fd88b"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -323,7 +326,7 @@ var element = $('#221bfcfa-4c16-4445-9eac-27d04f8fd88b');
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p><code>scatter</code> generates a scatter plot that allows interaction with the parameters to the response functions. 
+<p><code>scatter</code> generates a scatter plot that allows interaction with the parameters to the response functions.
 This is different from scatter_drag which facilitates interaction using click and drag actions.</p>
 <p>The first two arguments of <code>scatter</code> are response functions that return the x and y-axis coordinates, respectively. Either argument can be arrays themselves. Arguments for the response functions must be passed in as keyword arguments to <code>scatter</code> in the format expected by interact. The response function for the y-coordinates will be called with the x-coordinates as its first argument.</p></div></div></div>
 <div class="cell border-box-sizing code_cell rendered">
@@ -349,8 +352,8 @@ This is different from scatter_drag which facilitates interaction using click an
 
 
 
- 
- 
+
+
 <div id="037028ae-ffb8-4e60-b92f-7336436f9712"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -368,8 +371,8 @@ var element = $('#037028ae-ffb8-4e60-b92f-7336436f9712');
 
 
 
- 
- 
+
+
 <div id="95ff5b85-0954-4de3-b010-49c1487498bb"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -411,8 +414,8 @@ var element = $('#95ff5b85-0954-4de3-b010-49c1487498bb');
 
 
 
- 
- 
+
+
 <div id="23a72b18-f8dd-4cee-91aa-022be0e5e69b"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
@@ -430,8 +433,8 @@ var element = $('#23a72b18-f8dd-4cee-91aa-022be0e5e69b');
 
 
 
- 
- 
+
+
 <div id="47ebce77-83eb-4e03-aca3-a12cc9b912c2"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">

--- a/packages/gitbook-plugin-nbinteract/js/plugin.js
+++ b/packages/gitbook-plugin-nbinteract/js/plugin.js
@@ -1,11 +1,43 @@
 require(['gitbook'], function(gitbook) {
-  console.log('Initializing interact...');
-  var interact = new window.NbInteract()
+  var interact
+  var auto_run
 
-  window.interact = interact
+  gitbook.events.bind('page.change', function(e) {
+    var config = gitbook.state.config.pluginsConfig.nbinteract
+    var auto_run = config.auto_run
 
-  gitbook.events.bind('page.change', function() {
-    console.log('Running interact:');
-    interact.run()
+    if (interact === undefined) {
+      console.log('Initializing interact...')
+      var interact = new window.NbInteract(
+        (spec = config.spec),
+        (provider = config.provider),
+      )
+      window.interact = interact
+    }
+
+    if (auto_run) {
+      console.log('Running interact:')
+      interact.run()
+      return
+    }
+
+    var el = document.querySelector('#nbinteract')
+    if (!el) {
+      console.log(
+        `No HTML element with id="nbinteract" found. nbinteract is disabled for this page.`,
+      )
+      return
+    }
+
+    el.addEventListener('click', function(e) {
+      e.preventDefault()
+
+      // We're starting a kernel that will persist between page views so we
+      // might as well run whenever we can.
+      auto_run = true
+
+      console.log('Running interact:')
+      interact.run()
+    })
   })
 })

--- a/packages/gitbook-plugin-nbinteract/package.json
+++ b/packages/gitbook-plugin-nbinteract/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.25",
   "description": "Gitbook plugin for nbinteract",
   "main": "index.js",
-  "engines": {
-    "gitbook": ">=2.0.0"
-  },
   "scripts": {
     "test": "echo \"Error: no tests available\" && exit 1",
     "load": "cp ../nbinteract-core/lib/index.bundle.js ../nbinteract-core/lib/index.bundle.js.map js/"
@@ -22,6 +19,39 @@
     "widgets",
     "gitbook"
   ],
+  "engines": {
+    "gitbook": ">=3.0.0"
+  },
+  "gitbook": {
+    "properties": {
+      "spec": {
+        "type": "String",
+        "description": [
+          "Spec for the BinderHub image. Must be in the format ",
+          "${username}/${repo}/${branch}. By default uses the nbinteract ",
+          "image."
+        ],
+        "default": "SamLau95/nbinteract-image/master"
+      },
+      "provider": {
+        "type": "String",
+        "description": [
+          "Provider for the BinderHub image. ",
+          "By default uses Github."
+        ],
+        "default": "gh"
+      },
+      "auto_run": {
+        "type": "bool",
+        "description": [
+          "If true (default), automatically starts kernel and runs code when ",
+          "page with widgets is loaded. If false, will look for a DOM ",
+          "element with id nbinteract and attach a click handler to run."
+        ],
+        "default": true
+      }
+    }
+  },
   "author": "Sam Lau",
   "license": "BSD-3-Clause",
   "bugs": {

--- a/packages/nbinteract-core/src/NbInteract.js
+++ b/packages/nbinteract-core/src/NbInteract.js
@@ -1,61 +1,54 @@
 import debounce from 'lodash.debounce'
 import once from 'lodash.once'
 
-import { Kernel, ServerConnection, KernelMessage } from '@jupyterlab/services'
+import { Kernel, ServerConnection } from '@jupyterlab/services'
 
+import * as util from './util.js'
 import BinderHub from './BinderHub'
 import { WidgetManager } from './manager'
 
-const baseToWsUrl = baseUrl =>
-  'wss:' +
-  baseUrl
-    .split(':')
-    .slice(1)
-    .join(':')
+const DEFAULT_PROVIDER = 'gh'
+const DEFAULT_SPEC = 'SamLau95/nbinteract-image/master'
 
-const WIDGET_MSG = 'application/vnd.jupyter.widget-view+json'
-
-const cellToCode = cell => cell.querySelector('.input_area').textContent
-const isWidgetCell = cell => cell.querySelector('.output_widget_view') !== null
-const cellToWidgetOutput = cell => cell.querySelector('.output_widget_view')
-const removeLoadingFromCell = cell => {
-  // Keep in sync with interact_template.tpl
-  const el = cell.querySelector('.js-widget-loading-indicator')
-  if (el) el.remove()
-}
-
-const isErrorMsg = msg => msg.msg_type === 'error'
-const msgToModel = (msg, manager) => {
-  if (!KernelMessage.isDisplayDataMsg(msg)) {
-    return
-  }
-
-  const widgetData = msg.content.data[WIDGET_MSG]
-  if (widgetData === undefined || widgetData.version_major !== 2) {
-    return
-  }
-
-  const model = manager.get_model(widgetData.model_id)
-  return model
-}
-
-// Class that runs notebook code and creates widgets
-//
-// The constructor takes in the following optional arguments:
-// {
-//   record_messages: "Debugging argument that records all messages sent by
-//      kernel. Will increase memory usage.",
-// }
+/**
+ * Main entry point for nbinteract.
+ *
+ * Class that runs notebook code and creates widgets.
+ */
 export default class NbInteract {
-  constructor({ record_messages } = { record_messages: false }) {
+  /**
+   * Initialize NbInteract. Does not start kernel until run() is called.
+   *
+   * @param {String} [spec] - Spec for BinderHub image. Must be in the format:
+   *     `${username}/${repo}/${branch}`. Uses nbinteract-image by default.
+   *
+   * @param {String} [provider] - BinderHub provider. Uses GitHub by default.
+   *
+   * @param {bool} [record_messages=false] - Debugging argument that records
+   *     all messages sent by kernel. Will increase memory usage!
+   */
+  constructor(
+    spec = DEFAULT_SPEC,
+    provider = DEFAULT_PROVIDER,
+    record_messages = false,
+  ) {
     this._getOrStartKernel = once(this._getOrStartKernel)
     this.run = debounce(this.run, 500, { leading: true, trailing: false })
-    this.binder = new BinderHub()
+    this.binder = new BinderHub(spec, provider)
     // Record messages for debugging
     this.messages = record_messages ? [] : false
   }
 
   run() {
+    if (!util.pageHasWidgets()) {
+      console.log('No widgets detected, stopping nbinteract.')
+
+      // Warm up kernel so the next run is faster
+      this._getOrStartKernel()
+
+      return
+    }
+
     // Generates a semi-random length-4 string. Just used for logging, so no
     // need to be super complicated.
     // From https://stackoverflow.com/a/8084248
@@ -69,7 +62,7 @@ export default class NbInteract {
 
         codeCells.forEach((cell, i) => {
           console.time(`cell_${i}_${run_id}`)
-          const code = cellToCode(cell)
+          const code = util.cellToCode(cell)
           const execution = kernel.requestExecute({ code })
 
           execution.onIOPub = msg => {
@@ -77,21 +70,21 @@ export default class NbInteract {
               this.messages.push(msg)
             }
 
-            if (isErrorMsg(msg)) {
-              console.error('Error in code run:', msg.content);
+            if (util.isErrorMsg(msg)) {
+              console.error('Error in code run:', msg.content)
             }
 
             // If we have a display message, display the widget.
-            if (!isWidgetCell(cell)) {
+            if (!util.isWidgetCell(cell)) {
               return
             }
 
-            const model = msgToModel(msg, manager)
+            const model = util.msgToModel(msg, manager)
             if (model !== undefined) {
-              const outputEl = cellToWidgetOutput(cell)
+              const outputEl = util.cellToWidgetOutput(cell)
               model.then(model => {
                 manager.display_model(msg, model, { el: outputEl })
-                removeLoadingFromCell(cell)
+                util.removeLoadingFromCell(cell)
                 console.timeEnd(`cell_${i}_${run_id}`)
               })
             }
@@ -115,7 +108,7 @@ export default class NbInteract {
       // Connect to the notebook webserver.
       const serverSettings = ServerConnection.makeSettings({
         baseUrl: url,
-        wsUrl: baseToWsUrl(url),
+        wsUrl: util.baseToWsUrl(url),
         token: token,
       })
       console.timeEnd('start_server')

--- a/packages/nbinteract-core/src/util.js
+++ b/packages/nbinteract-core/src/util.js
@@ -1,0 +1,54 @@
+/**
+ * Private utility functions used primarily by NbInteract.js
+ */
+
+import { KernelMessage } from '@jupyterlab/services'
+
+/**
+ * Converts a notebook HTTP URL to a WebSocket URL
+ */
+export const baseToWsUrl = baseUrl =>
+  'wss:' +
+  baseUrl
+    .split(':')
+    .slice(1)
+    .join(':')
+
+/**
+ * Message type for widgets
+ */
+export const WIDGET_MSG = 'application/vnd.jupyter.widget-view+json'
+
+/**
+ * Functions to work with notebook DOM
+ */
+export const pageHasWidgets = () =>
+  document.querySelector('.output_widget_view') !== null
+export const cellToCode = cell => cell.querySelector('.input_area').textContent
+export const isWidgetCell = cell =>
+  cell.querySelector('.output_widget_view') !== null
+export const cellToWidgetOutput = cell =>
+  cell.querySelector('.output_widget_view')
+export const removeLoadingFromCell = cell => {
+  // Keep in sync with interact_template.tpl
+  const el = cell.querySelector('.js-widget-loading-indicator')
+  if (el) el.remove()
+}
+
+/**
+ * Functions to work with kernel messages
+ */
+export const isErrorMsg = msg => msg.msg_type === 'error'
+export const msgToModel = (msg, manager) => {
+  if (!KernelMessage.isDisplayDataMsg(msg)) {
+    return
+  }
+
+  const widgetData = msg.content.data[WIDGET_MSG]
+  if (widgetData === undefined || widgetData.version_major !== 2) {
+    return
+  }
+
+  const model = manager.get_model(widgetData.model_id)
+  return model
+}


### PR DESCRIPTION
This PR allows the gitbook plugin to take in the following config:

```js
"spec": {
  "type": "String",
  "description": [
    "Spec for the BinderHub image. Must be in the format ",
    "${username}/${repo}/${branch}. By default uses the nbinteract ",
    "image."
  ],
  "default": "SamLau95/nbinteract-image/master"
},
"provider": {
  "type": "String",
  "description": [
    "Provider for the BinderHub image. ",
    "By default uses Github."
  ],
  "default": "gh"
},
"auto_run": {
  "type": "bool",
  "description": [
    "If true (default), automatically starts kernel and runs code when ",
    "page with widgets is loaded. If false, will look for a DOM ",
    "element with id nbinteract and attach a click handler to run."
  ],
  "default": true
}
```

This means that we can safely deploy this to popular textbooks like Data
8's as long as we turn off auto_run :).