### PR TITLE
Add --no-top-button flag to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ to keep track of.
 
 **Python**
 
+Features:
+
+- The `nbinteract` CLI now has a `--no-top-button` flag to remove the top-level
+  button.
+
 Bug fixes:
 
 - Python 3.4 doesn't support the `{**dict1, **dict2}` syntax, so we merge

--- a/docs/recipes/recipes_exporting.md
+++ b/docs/recipes/recipes_exporting.md
@@ -63,6 +63,8 @@ converting notebooks into HTML pages. It work identically to `nbi.publish()`
 but can be used on the command line.
 
 ```
+Converts notebooks to interactive HTML pages or Gitbook pages.
+
 Usage:
   nbinteract SPEC NOTEBOOKS ...
   nbinteract [options] SPEC NOTEBOOKS ...
@@ -87,6 +89,7 @@ Options:
                              types: full (standalone page), partial (embeddable
                              page), or gitbook (embeddable page for GitBook).
                              [default: full]
+  -B --no-top-button         If set, doesn't generate button at top of page.
   -r --recursive             Recursively convert notebooks in subdirectories.
   -o FOLDER --output=FOLDER  Outputs HTML files into FOLDER instead of
                              outputting files adjacent to their originating

--- a/nbinteract/nbinteract
+++ b/nbinteract/nbinteract
@@ -25,6 +25,7 @@ Options:
                              types: full (standalone page), partial (embeddable
                              page), or gitbook (embeddable page for GitBook).
                              [default: full]
+  -B --no-top-button         If set, doesn't generate button at top of page.
   -r --recursive             Recursively convert notebooks in subdirectories.
   -o FOLDER --output=FOLDER  Outputs HTML files into FOLDER instead of
                              outputting files adjacent to their originating
@@ -88,7 +89,10 @@ def main():
     )
 
     exporter = init_exporter(
-        template=arguments['--template'], extract_images=arguments['--images']
+        extract_images=arguments['--images'],
+        spec=arguments['SPEC'],
+        template_file=arguments['--template'],
+        button_at_top=(not arguments['--no-top-button'])
     )
 
     log('Converting notebooks to HTML...')
@@ -150,20 +154,19 @@ def expand_folder(notebook_or_folder, recursive=False):
         )
 
 
-def init_exporter(template, extract_images):
+def init_exporter(extract_images, **exporter_config):
     """
     Returns an initialized exporter.
     """
-    # Use ExtractOutputPreprocessor to extract the images to separate files
-    config = Config()
+    config = Config(InteractExporter=exporter_config)
+
     if extract_images:
+        # Use ExtractOutputPreprocessor to extract the images to separate files
         config.InteractExporter.preprocessors = [
             'nbconvert.preprocessors.ExtractOutputPreprocessor',
         ]
 
     exporter = InteractExporter(config=config)
-    exporter.template_file = template
-
     return exporter
 
 

--- a/nbinteract/templates/gitbook.tpl
+++ b/nbinteract/templates/gitbook.tpl
@@ -47,12 +47,13 @@ This makes the gitbook template the simplest one.
 {# Add button at top to run all widgets #}
 {% block body %}
 
-{# Keep class in sync with util.js #}
-<div class="cell border-box-sizing text_cell rendered">
-  <button class="{{ nbinteract_class }}">
-    Show Widgets
-  </button>
-</div>
+{% if button_at_top %}
+  <div class="cell border-box-sizing text_cell rendered">
+    <button class="{{ nbinteract_class }}">
+      Show Widgets
+    </button>
+  </div>
+{% endif %}
 
 {{ super() }}
 {% endblock body %}


### PR DESCRIPTION
The CLI now supports a `--no-top-button` flag to stop the top-level button from
being generated.