### PR TITLE
Fixes `spec` CLI argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ Features:
 Bug fixes:
 
 - Python 3.4 doesn't support the `{**dict1, **dict2}` syntax, so we merge
-  dictionaries another way to support older versions of Python
-- Fixes an issue that broke `nbinteract` CLI (#52)
+  dictionaries another way to support older versions of Python.
+- Fixes an issue that broke `nbinteract` CLI completely (#52).
+- The `nbinteract` CLI spec argument didn't actually set the spec properly.
 
 **JS**
 

--- a/nbinteract/exporters.py
+++ b/nbinteract/exporters.py
@@ -62,7 +62,7 @@ class InteractExporter(HTMLExporter):
     spec = Unicode(
         'SamLau95/nbinteract-image/master',
         help='BinderHub spec for Jupyter image.'
-    )
+    ).tag(config=True)
 
     base_url = Unicode(
         'https://mybinder.org', help='Base Binder URL.'


### PR DESCRIPTION
Since we didn't allow the `spec` to be set through a traitlets Config,
the converter always defaulted to `SamLau95/nbinteract-image/master`.