### PR TITLE
Add nbinteract init CLI commend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ to keep track of.
 
 **Python**
 
+Features:
+
+- `nbinteract init` initializes a GitHub repo for nbinteract.
+
 **JS**
 
 Bug fixes:
 
-- Fixes console errors from cells that don't have widget output.
+- Fixes errors from cells that don't have widget output.
 
 ## 0.1.3
 


### PR DESCRIPTION
The `nbinteract init` should help make initializing a repo for nbinteract
easier. It checks for a requirements.txt and outputs a link to a Binder URL
so the user can check their image.