### PR TITLE
Revert "added seaborn module"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ ipywidgets>=7, <7.2
 toolz>=0.8, <1
 docopt>=0.6.2, <0.7
 nbformat>=4.4.0, <5
-seaborn>=0.8.1, <0.9


### PR DESCRIPTION
Reverts SamLau95/nbinteract#67

I realize that this addition won't actually fix the issue since the `requirements.txt` file here is only used for the package, not for the Binder image.