### PR TITLE
Set encoding for all `open()` calls

### DIFF
--- a/docs/convert_notebooks_to_html_partial.py
+++ b/docs/convert_notebooks_to_html_partial.py
@@ -79,7 +79,7 @@ def convert_notebooks_to_html_partial(notebook_paths):
 
         # Write out HTML
         outfile_path = os.path.join(os.curdir, NOTEBOOK_HTML_DIR, outfile_name)
-        with open(outfile_path, 'w') as outfile:
+        with open(outfile_path, 'w', encoding='utf-8') as outfile:
             outfile.write(final_output)
 
         # Write out images

--- a/nbinteract/cli.py
+++ b/nbinteract/cli.py
@@ -173,7 +173,7 @@ def run_converter(arguments):
     """
     # Get spec from config file
     if os.path.isfile(CONFIG_FILE):
-        with open(CONFIG_FILE) as f:
+        with open(CONFIG_FILE, encoding='utf-8') as f:
             config = json.load(f)
             arguments['--spec'] = arguments['--spec'] or config['spec']
 
@@ -255,7 +255,7 @@ def init():
         )
         if yes:
             # TODO(sam): Don't hard-code requirements.txt
-            with open('requirements.txt', 'w') as f:
+            with open('requirements.txt', 'w', encoding='utf-8') as f:
                 f.writelines(['numpy\n', 'nbinteract\n'])
             log(
                 'Created requirements.txt. Edit this file now to include the '
@@ -305,7 +305,7 @@ def init():
         )
 
     binder_spec = binder_spec_from_github_url(github_origin)
-    with open(CONFIG_FILE, 'w') as f:
+    with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
         json.dump({'spec': binder_spec}, f, indent=4)
     log('Created .nbinteract.json file successfully')
     log()
@@ -450,7 +450,7 @@ def convert(notebook_path, exporter, output_folder=None, images_folder=None):
     # folder of the notebook
     out_folder = path if not output_folder else output_folder
     outfile_path = os.path.join(out_folder, outfile_name)
-    with open(outfile_path, 'w') as outfile:
+    with open(outfile_path, 'w', encoding='utf-8') as outfile:
         outfile.write(final_output)
 
     # Write out images. If images_folder wasn't specified, resources['outputs']

--- a/notebooks/test.py
+++ b/notebooks/test.py
@@ -4,10 +4,10 @@ import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-with open('Test.ipynb') as f:
+with open('Test.ipynb', encoding='utf-8') as f:
     nb = nbformat.read(f, 4)
 
 executed = executenb(nb)
 
-with open('Test_Executed.ipynb', 'w') as f:
+with open('Test_Executed.ipynb', 'w', encoding='utf-8') as f:
     nbformat.write(executed, f)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,7 +75,7 @@ def convert_one(notebook, cli_args={}, name_only=False):
     if name_only:
         yield html_file
     else:
-        with open(html_file) as f:
+        with open(html_file, encoding='utf-8') as f:
             yield f
 
     os.remove(html_file)


### PR DESCRIPTION
Fixes https://github.com/SamLau95/nbinteract/issues/78

This avoids encoding issues on Windows where the default encoding is
`cp1252` instead of `utf-8`.

See https://docs.python.org/3/library/codecs.html#encodings-and-unicode
for reference.