### PR TITLE
Make spec branch optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ to keep track of.
 
 ## master
 
+## 0.2.1
+
+**Python**
+
+Features:
+
+- When publishing, the branch name of the spec is now optional (defaults to
+  `master`) (https://github.com/SamLau95/nbinteract/pull/91).
+
 ## 0.2.0
 
 **JS**

--- a/nbinteract/cli.py
+++ b/nbinteract/cli.py
@@ -29,7 +29,8 @@ Options:
                              format: `{username}/{repo}/{branch}`. For example:
                              'SamLau95/nbinteract-image/master'. This flag is
                              **required** unless a .nbinteract.json file exists
-                             in the project root with the "spec" key.
+                             in the project root with the "spec" key. If branch
+                             is not specified, default to `master`.
   -t TYPE --template TYPE    Specifies the type of HTML page to generate. Valid
                              types: full (standalone page), partial (embeddable
                              page with library), or plain (embeddable page
@@ -73,7 +74,7 @@ CONFIG_FILE = '.nbinteract.json'
 
 VALID_TEMPLATES = set(['full', 'plain', 'partial', 'local'])
 
-SPEC_REGEX = re.compile('\S+/\S+/\S+')
+SPEC_REGEX = re.compile('\S+/\S+(/\S+)?')
 
 BINDER_BASE_URL = 'https://mybinder.org/v2/gh/'
 REQUIREMENTS_DOCS = 'http://mybinder.readthedocs.io/en/latest/using.html#id8'


### PR DESCRIPTION
This comment allows the use of specs like `samlau95/nbinteract-image`
instead of always requiring `samlau95/nbinteract-image/master`. By
default, the `master` branch will be used.