### PR TITLE
Remove top level button properly when widgets render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ to keep track of.
 
 ## 0.2.1
 
+**JS**
+
+Bug fixes:
+
+- Ensure top level button gets removed when widgets render (https://github.com/SamLau95/nbinteract/pull/92)
+
 **Python**
 
 Features:

--- a/packages/nbinteract-core/src/manager.js
+++ b/packages/nbinteract-core/src/manager.js
@@ -77,7 +77,7 @@ export class WidgetManager extends HTMLManager {
     const model = await util.msgToModel(msg, this)
     if (model) {
       // Remove all widget buttons
-      util.removeButtons(cell)
+      util.removeButtons()
 
       // Display widget
       const outputEl = util.cellToWidgetOutput(cell)


### PR DESCRIPTION
Before, the top-level button would never disappear after widgets render.
Now, it disappears properly.