### PR TITLE
'nbinteract init' bug in binder_spec_from_github_url

### DIFF
--- a/nbinteract/cli.py
+++ b/nbinteract/cli.py
@@ -98,7 +98,9 @@ def binder_spec_from_github_url(github_url):
     git@github.com:SamLau95/nbinteract.git -> SamLau95/nbinteract/master
     https://github.com/Calebs97/riemann_book -> Calebs97/riemann_book/master
     """
-    tokens = re.split(r'/|:', github_url.replace('.git', ''))
+    if github_url.endswith('.git'):
+        github_url = github_url[:-4]
+    tokens = re.split(r'/|:', github_url)
     # The username and reponame are the last two tokens
     return '{}/{}/master'.format(tokens[-2], tokens[-1])
 


### PR DESCRIPTION
The implementation of binder_spec_from_github_url was removing all '.git' substrings, which was causing a bug for github pages or any repo with 'git' in the title.
Eg. My repo https://github.com/samlaf/samlaf.github.io was resulting in the spec 'samlaf/samlafhub.io/master' instead of 'samlaf/samlaf.github.io/master'.
This pull request fixes that.