### PR TITLE
Relax nbconvert requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1, <2
 IPython>=6, <8
-nbconvert>=5.3, <6
+nbconvert>=5.3
 traitlets>=4.3, <5
 toolz>=0.8, <1
 docopt>=0.6.2, <1


### PR DESCRIPTION
With the new pip resolver changes, this pin prevents
nbinteract & voila from being installed together. Previously,
pip just ignored this and gave you a new version of nbconvert
anyway. Hopefully, this pin relaxation doesn't break anything
and makes co-existence with voila (and other future packages)
possible.